### PR TITLE
Filter .txt files and update runtime to provided.al2023

### DIFF
--- a/logs_processor/logs_processor.go
+++ b/logs_processor/logs_processor.go
@@ -21,6 +21,12 @@ const (
 )
 
 func ProcessLogs(s3Object *s3.GetObjectOutput, logger *zap.Logger, key, bucket, awsRegion string) [][]byte {
+	// Check if the file extension is .txt. If not, ignore the file.
+	if !strings.HasSuffix(strings.ToLower(key), ".txt") {
+		logger.Info("Ignoring file due to unsupported file type", zap.String("key", key))
+		return nil
+	}
+
 	logs := make([][]byte, 0)
 	var logsJsons []map[string]interface{}
 	var logsStr string

--- a/sam-template.yaml
+++ b/sam-template.yaml
@@ -55,7 +55,7 @@ Resources:
   LogzioS3HookLambda:
     Type: 'AWS::Serverless::Function'
     Properties:
-      Runtime: go1.x
+      Runtime: provided.al2023
       Handler: main
       CodeUri:
         Bucket: logzio-aws-integrations-<<REGION>>


### PR DESCRIPTION
Implemented filtering to process only `.txt` files and updated the Lambda runtime to `provided.al2023`. 
These changes streamline file processing and align with the latest AWS standards.
